### PR TITLE
Fix get_full_path with empty directory_path (for device path)

### DIFF
--- a/libcpath/libcpath_path.c
+++ b/libcpath/libcpath_path.c
@@ -1350,7 +1350,7 @@ int libcpath_path_get_full_path(
 		}
 		current_directory_segment_index = current_directory_number_of_segments - 1;
 	}
-	if( libcsplit_narrow_split_string_get_number_of_segments(
+	if( path_split_string != NULL && libcsplit_narrow_split_string_get_number_of_segments(
 	     path_split_string,
 	     &path_number_of_segments,
 	     error ) != 1 )
@@ -2127,7 +2127,7 @@ int libcpath_path_get_full_path(
 		}
 		current_directory_segment_index = current_directory_number_of_segments - 1;
 	}
-	if( libcsplit_narrow_split_string_get_number_of_segments(
+	if( path_split_string != NULL && libcsplit_narrow_split_string_get_number_of_segments(
 	     path_split_string,
 	     &path_number_of_segments,
 	     error ) != 1 )
@@ -4916,7 +4916,7 @@ int libcpath_path_get_full_path_wide(
 		}
 		current_directory_segment_index = current_directory_number_of_segments - 1;
 	}
-	if( libcsplit_wide_split_string_get_number_of_segments(
+	if( path_split_string != NULL && libcsplit_wide_split_string_get_number_of_segments(
 	     path_split_string,
 	     &path_number_of_segments,
 	     error ) != 1 )
@@ -5693,7 +5693,7 @@ int libcpath_path_get_full_path_wide(
 		}
 		current_directory_segment_index = current_directory_number_of_segments - 1;
 	}
-	if( libcsplit_wide_split_string_get_number_of_segments(
+	if( path_split_string != NULL && libcsplit_wide_split_string_get_number_of_segments(
 	     path_split_string,
 	     &path_number_of_segments,
 	     error ) != 1 )


### PR DESCRIPTION
Due https://github.com/libyal/libcpath/blob/main/libcpath/libcpath_path.c#L1063 :
```
 * Scenario's that are considered full paths:
 * Device path:			\\.\PhysicalDrive0
```
Should allowed for `\\.\PhysicalDrive0`
There is tests:
```
#include <stdlib.h>
#include <libcpath.h>
#include <../common/memory.h>

int main()
{
	const char c_device[] = "\\\\.\\PhysicalDrive0";

	libcpath_error_t* err = NULL;
	char* full_path = NULL;
	size_t full_path_size = 0;
	if (libcpath_path_get_full_path(
		c_device,
		sizeof(c_device) - 1,
		&full_path,
		&full_path_size,
		&err) != 1)
	{
		char msg[2048];
		char bt[4096];
		libcpath_error_sprint(err, msg, sizeof(msg) - 1);
		libcpath_error_backtrace_sprint(err, bt, sizeof(bt) - 1);
		fprintf(stderr, "Get full path failed:\n%s\n%s\n", msg, bt);
		libcpath_error_free(&err);
		return -1;
	}

	if (full_path)
	{
		printf("Full_path: %s\n", full_path);
		memory_free(full_path);
	}
	return 0;
}
```
Test failed with this:
```
Get full path failed:
libcpath_path_get_full_path: unable to retrieve number of path string segments.
libcsplit_narrow_split_string_get_number_of_segments: invalid split string.
libcpath_path_get_full_path: unable to retrieve number of path string segments.

```
It is because on https://github.com/libyal/libcpath/blob/main/libcpath/libcpath_path.c#L1283 `path_directory_name_index` point to empty string. As result `path_split_string` is `NULL` (but `libcsplit_narrow_string_split` returned 1 https://github.com/libyal/libcsplit/blob/main/libcsplit/libcsplit_narrow_string.c#L97)
Some later trying to get number of segments: https://github.com/libyal/libcpath/blob/main/libcpath/libcpath_path.c#L2130
But as `path_split_string` is `NULL`, that it failed(https://github.com/libyal/libcsplit/blob/main/libcsplit/libcsplit_narrow_split_string.c#L352).
So need to check `path_split_string` on `NULL` before `libcsplit_narrow_split_string_get_number_of_segments`.

With this PR test is successful:
`Full_path: \\.\PhysicalDrive0`




